### PR TITLE
Fix Note Groups not appearing

### DIFF
--- a/src/library/boomiapp/groups.js
+++ b/src/library/boomiapp/groups.js
@@ -45,7 +45,7 @@ const create_note_group = (el) => {
 
             let matched_icon = [...nodeParent.querySelectorAll(':not([data-notegroup]')].reverse().find(child => {
                 try {
-                    if (parseInt(child.style.top) == parseInt(node.style.top) - 23 && parseInt(child.style.left) == parseInt(node.style.left) && child.querySelector('.gwt-Image')) return true;
+                    if (parseInt(child.style.top) == parseInt(node.style.top) - 15 && parseInt(child.style.left) == parseInt(node.style.left) && child.querySelector('.gwt-Image')) return true;
                 } catch (error) {}
             })
 


### PR DESCRIPTION
Note groups weren't appearing due to styling changes they made in the March release (they took away the border around notes). This fix adjusts the match criteria to account for the adjusted note radius not being so large.