### PR TITLE
Minor Change: Adjust Toggle Markdown button styling to match rest of option buttons

### DIFF
--- a/src/library/boomiapp/descriptionMarkdown.js
+++ b/src/library/boomiapp/descriptionMarkdown.js
@@ -35,7 +35,7 @@ const add_description_listener = (description) => {
     }
 
     let toggle_html = `
-    <a class="fonticon_anchor icon-eye bph-markdown-toggle" onclick="toggleMarkdown(this)">Toggle Markdown</a>
+    <a class="gwt-Anchor svg_decorated_anchor icon-eye bph-markdown-toggle" onclick="toggleMarkdown(this)">Toggle Markdown</a>
     `;
     description.closest('.component_header').querySelector('.links').insertAdjacentHTML('beforeend', toggle_html);
 


### PR DESCRIPTION
Boomi has adjusted the styling slightly for these options buttons. This change will bring the Toggle Markdown button to be vertically centered with the other icons. Note: This does remove the underline from the icon (but it matches the other native platform icons)

**Before**
<img width="369" alt="Screen Shot 2023-05-31 at 9 10 44 PM" src="https://github.com/mitchelljfranklin/Boomi-Platform-Extension/assets/58959675/7e481a15-2254-423d-8b3a-a246c79378a5">
**After**
<img width="368" alt="Screen Shot 2023-05-31 at 9 10 20 PM" src="https://github.com/mitchelljfranklin/Boomi-Platform-Extension/assets/58959675/a69fd8df-2d3a-4df1-832e-eab77df4ac07">
