### PR TITLE
Fix Collapse button showing on other dialogs

### DIFF
--- a/src/library/boomiapp/filterButtons.js
+++ b/src/library/boomiapp/filterButtons.js
@@ -1,6 +1,8 @@
 document.arrive(".filter_panel_dialog_popup_panel", function (filterpanel) {
-    var buttonBar = document.getElementsByClassName('button-bar')
-    buttonBar[0].insertAdjacentHTML('beforeend', '<button id="colaButton" type="button" class="gwt-Button qm-button--primary-action closeall_doing_action" data-locator="button-filter">Collapse All Folders</button>')
+    if(filterpanel.querySelector(".filterable_tree_loading_container")){
+        var buttonBar = document.getElementsByClassName('button-bar')
+        buttonBar[0].insertAdjacentHTML('beforeend', '<button id="colaButton" type="button" class="gwt-Button qm-button--primary-action closeall_doing_action" data-locator="button-filter">Collapse All Folders</button>')
+    }
 });
 
 


### PR DESCRIPTION
The Collapse All Folders button was being added to other dropdown dialogs such as Date/Time filters and Atom filters. The snippet I added should only allow the button to be inserted on the process tree dialog. (Tested on Process Reporting, Deployments and Packaged Components pages)